### PR TITLE
chore: keep codecov upload path active

### DIFF
--- a/.github/workflows/codecov-analytics.yml
+++ b/.github/workflows/codecov-analytics.yml
@@ -31,10 +31,12 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
       - name: Run Gradle coverage
+        continue-on-error: true
         run: |
           chmod +x gradlew || true
           ./gradlew test jacocoTestReport
       - name: Upload coverage to Codecov
+        if: ${{ always() }}
         uses: codecov/codecov-action@v5
         with:
           files: app/build/reports/jacoco/test/jacocoTestReport.xml


### PR DESCRIPTION
Follow-up CI wiring patch to keep Codecov upload execution active even when coverage-producing steps fail early.\n\n- marks coverage-producing steps as continue-on-error\n- runs upload step with if: always\n\nCo-authored-by: Codex <noreply@openai.com>