### PR TITLE
ci: pin 3rd-party actions to commit SHAs (2 CodeQL actions/unpinned-tag alerts)

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -20,6 +20,6 @@ jobs:
         with:
           distribution: temurin
           java-version: '17'
-      - uses: gradle/actions/setup-gradle@v3
-      - uses: android-actions/setup-android@v3
+      - uses: gradle/actions/setup-gradle@d9c87d481d55275bb5441eef3fe0e46805f9ef70 # v3
+      - uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # v3
       - run: bash scripts/verify


### PR DESCRIPTION
## **User description**
## Leverage play: SHA-pin third-party GitHub Actions (config-only, no-build-needed safe play)

Part of the **quality-zero-platform drive-to-zero** campaign.

### What this does
Pins the two third-party Actions in `.github/workflows/verify.yml` to full 40-char commit SHAs (with `# v3` version comments):

| Step | Before | After |
|------|--------|-------|
| `gradle/actions/setup-gradle` | `@v3` | `@d9c87d481d55275bb5441eef3fe0e46805f9ef70 # v3` |
| `android-actions/setup-android` | `@v3` | `@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # v3` |

### Findings cleared
Resolves the **2 open CodeQL `actions/unpinned-tag` alerts** (#2 line 23, #3 line 24 — both medium severity). These are the only "3rd-party Action pinned to a mutable tag" findings in the repo.

### Scope discipline
- GitHub-owned `actions/*` steps (`checkout`, `setup-java`, `github-script`) are **not** flagged by `actions/unpinned-tag` and were intentionally left untouched — pinning them would clear zero alerts.
- The `Prekzursil/quality-zero-platform/*` reusable workflows are already SHA-pinned.
- The `# v3` comments preserve the version anchor the repo's existing Dependabot `github-actions` updater uses to keep these pins bumped.

### Verification
- Behavior-preserving: the pinned SHAs are exactly what `v3` currently resolves to (`gh api repos/<action>/commits/v3`).
- `verify.yml` validated as well-formed YAML (PyYAML `safe_load`).
- Full Android build/test (`./gradlew testDebugUnitTest lintDebug`) was **not** runnable locally (no Android SDK in this environment); this change touches CI config only and does not affect app code or the build graph.

### Out of scope (reported, not attempted)
The remaining 74 CodeQL alerts are Java semantic findings that are **not** safe uniform mechanical transforms and need build-verified manual work (signature changes for `unused-parameter`, control-flow changes for `uncaught-number-format-exception`, the lone error-severity `java/unused-container`, and the high-severity security cluster: `cleartext-storage-database` x6, `polynomial-redos` x2, `backup-enabled`, `missing-certificate-pinning`). Coverage to 100% is a build-setup task (zero test sources — only `src/main`; no JaCoCo plugin applied; Android SDK required).

> Operator reviews/merges. No auto-merge. No secrets touched.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pinned `gradle/actions/setup-gradle` and `android-actions/setup-android` in `.github/workflows/verify.yml` to exact commit SHAs to lock versions and prevent tag drift. Clears 2 CodeQL `actions/unpinned-tag` alerts; CI behavior unchanged.

<sup>Written for commit 06f787238c9528dfc6038f3b08fa7bfc04483863. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Prekzursil/Personal-Finance-Management/pull/30?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Pin third-party GitHub Actions in the verify workflow**

### What Changed
- The verify workflow now uses fixed commit versions for the Gradle and Android setup actions instead of floating `v3` tags
- This keeps CI behavior tied to the same action versions and prevents upstream tag changes from altering the workflow

### Impact
`✅ Fewer CI surprises from upstream action updates`
`✅ Clearer GitHub security alerts`
`✅ More stable verify runs`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
