### PR TITLE
ci: add lean 6-gate quality template (additive)

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -18,4 +18,4 @@ concurrency:
 
 jobs:
   quality:
-    uses: Prekzursil/quality-zero-platform/.github/workflows/reusable-quality.yml@feat/lean-quality-template
+    uses: Prekzursil/quality-zero-platform/.github/workflows/reusable-quality.yml@v1

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1,0 +1,21 @@
+# Lean 6-gate quality (charter 2026-06-16). Thin ADDITIVE caller into the shared
+# reusable template. Pinned to the template branch so this PR's CI is real now;
+# the migration runbook re-pins to a tag after the template merges.
+name: quality
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: quality-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  quality:
+    uses: Prekzursil/quality-zero-platform/.github/workflows/reusable-quality.yml@feat/lean-quality-template

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,31 @@
+# gitleaks configuration for the lean secrets gate (pinned tool: gitleaks 8.30.1).
+# The gate runs via pre-commit over the working tree and must report 0 findings.
+# Extends the upstream default ruleset; we only add path/match allowlists for
+# generated / vendored trees and genuine non-secret fixtures (no real secrets).
+title = "personal-finance-management lean secrets gate"
+
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Generated/vendored trees and reasoned non-secrets (not real secrets)."
+
+paths = [
+  '''(^|/)\.venv/''',
+  '''(^|/)node_modules/''',
+  '''(^|/)vendor/''',
+  '''(^|/)build/''',
+  '''(^|/)out/''',
+  '''(^|/)dist/''',
+  '''(^|/)\.git/''',
+  '''.*\.egg-info/''',
+  # Android Gradle wrapper jar (binary, upstream artifact).
+  '''(^|/)gradle/wrapper/gradle-wrapper\.jar$''',
+  # Firebase/Google Android CLIENT config. The "api_key.current_key" in this file
+  # is a Google Android API client key, NOT a server secret: it is designed to be
+  # bundled in the shipped APK and is access-restricted by Android package name +
+  # SHA-1 signing-cert fingerprint on the Google side (Google documents committing
+  # google-services.json to source control as safe). Already public in the APK and
+  # in git history; not an undisclosed credential. Reason-dated 2026-06-17.
+  '''(^|/)app/google-services\.json$''',
+]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,50 @@
+# Lean quality gates -- local auto-fixers + fast checks (charter 2026-06-16).
+# `pre-commit run --all-files` is the gate-1/gate-5 entrypoint used by CI
+# (reusable-quality.yml). Every rev is pinned; bump versions here together with
+# the gate workflow.
+#
+# This repo's APPLICATION is pure Java/Android. The only Python in the tree is the
+# legacy quality-zero-platform (QZT) SaaS helper machinery under scripts/, which
+# carries its own QZT commit/type contracts and is slated for removal in the
+# migration runbook -- it is NOT linted/reformatted by the lean gate (out of scope,
+# would violate QZT's py2-compat contract). The Python lint/format hooks below are
+# therefore scoped to application Python under app/ (none today; ready for future).
+# Java auto-formatting (Spotless) is wired into Gradle, not pre-commit.
+minimum_pre_commit_version: "3.5.0"
+
+default_language_version:
+  python: python3
+
+exclude: |-
+  (?x)^(
+    scripts/|
+    node_modules/|
+    build/|
+    out/|
+    dist/|
+    vendor/|
+    \.venv/|
+    gradle/wrapper/|
+    .*\.egg-info/
+  )
+
+repos:
+  # --- Gate 1: Python lint + format (ruff), scoped to application code (app/) ---
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.17
+    hooks:
+      - id: ruff
+        name: ruff (lint --fix)
+        args: ["--fix"]
+        files: '^app/.*\.py$'
+      - id: ruff-format
+        name: ruff (format)
+        files: '^app/.*\.py$'
+
+  # --- Gate 5: secrets (gitleaks) over the working tree, must report 0 ---
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.30.1
+    hooks:
+      - id: gitleaks
+        name: gitleaks (secrets)
+        args: ["--config", ".gitleaks.toml"]

--- a/.quality/opengrep/README.md
+++ b/.quality/opengrep/README.md
@@ -1,0 +1,43 @@
+# Curated SAST ruleset (Gate 4)
+
+Pinned tool: **opengrep 1.22.0** (CI) — locally interchangeable with **semgrep CE**
+(opengrep is a fork of semgrep and consumes the same rule syntax).
+
+## Why an in-repo ruleset instead of `--config auto`
+
+`--config auto` / `p/*` registry packs are fetched from the network at scan time and
+change underneath you, which makes the gate **non-deterministic**. The lean model
+requires a fixed, reviewable ruleset committed to the repo, so the gate produces the
+same result every run, offline, with no registry login.
+
+## Contents
+
+A **curated subset** distilled from the relevant upstream packs (`p/java`,
+`p/r2c-security-audit`) — the high-signal security rules that apply to this
+Java/Android (`com.thriftyApp`) codebase:
+
+- `java-security.yaml` — Java/Android command-injection / SQL-injection /
+  weak-crypto / TLS-trust-all / WebView-JS patterns.
+- `general-security.yaml` — language-agnostic patterns (private keys / cloud
+  access keys committed to source).
+
+Upstream registry rules are Apache-2.0 / LGPL-2.1 licensed; rule logic is reproduced /
+adapted here. To refresh against upstream, diff the registry packs and port new
+high-signal rules in (one-in-one-out review).
+
+## Running the gate
+
+```bash
+# CI (opengrep on Linux), matching .github/workflows/quality.yml gate-sast step:
+opengrep scan --config .quality/opengrep --error \
+  --exclude .venv --exclude node_modules --exclude dist --exclude out --exclude build \
+  .
+
+# Local (semgrep CE, rule-compatible):
+semgrep scan --config .quality/opengrep --error --metrics off \
+  --exclude node_modules --exclude build --exclude out .
+```
+
+Gate passes on **0 findings** (clean-zero lock; no baseline file). Genuine
+false-positives are suppressed inline with a greppable
+`// nosemgrep: <rule-id> -- <reason>`.

--- a/.quality/opengrep/general-security.yaml
+++ b/.quality/opengrep/general-security.yaml
@@ -1,0 +1,37 @@
+# Curated language-agnostic security rules (subset of p/r2c-security-audit).
+# opengrep/semgrep compatible. See README.md.
+rules:
+  - id: generic-private-key-committed
+    languages: [generic]
+    severity: ERROR
+    message: >-
+      A PEM private key block appears to be committed to source. Private keys
+      must never live in the repo; use a secret manager / env vars.
+    metadata:
+      category: security
+      cwe: "CWE-798: Use of Hard-coded Credentials"
+    paths:
+      exclude:
+        - "*.example"
+        - "**/test/**"
+        - "**/tests/**"
+        - "**/fixtures/**"
+    patterns:
+      - pattern-regex: "-----BEGIN (RSA |EC |OPENSSH |DSA |PGP )?PRIVATE KEY-----"
+
+  - id: generic-aws-access-key-id
+    languages: [generic]
+    severity: ERROR
+    message: >-
+      A string matching an AWS Access Key ID was found. Rotate it and move
+      credentials to a secret manager / environment variables.
+    metadata:
+      category: security
+      cwe: "CWE-798"
+    paths:
+      exclude:
+        - "*.example"
+        - "**/test/**"
+        - "**/tests/**"
+    patterns:
+      - pattern-regex: "\b(AKIA|ASIA)[0-9A-Z]{16}\b"

--- a/.quality/opengrep/java-security.yaml
+++ b/.quality/opengrep/java-security.yaml
@@ -1,0 +1,73 @@
+# Curated Java/Android security rules (high-signal subset distilled from
+# p/java + p/r2c-security-audit). opengrep/semgrep compatible. See README.md.
+# Clean-zero gate: 0 findings. Suppress a genuine false positive inline with a
+# greppable `// nosemgrep: <rule-id> -- <reason>`.
+rules:
+  - id: java-runtime-exec-tainted
+    languages: [java]
+    severity: ERROR
+    message: >-
+      Runtime.exec / ProcessBuilder invoked with a dynamically built command.
+      Risk of OS command injection (CWE-78). Use a fixed argv and validate input.
+    metadata:
+      category: security
+      cwe: "CWE-78: OS Command Injection"
+    patterns:
+      - pattern-either:
+          - pattern: Runtime.getRuntime().exec($CMD + ...)
+          - pattern: new ProcessBuilder($CMD + ...)
+
+  - id: java-sql-string-concat
+    languages: [java]
+    severity: ERROR
+    message: >-
+      SQL statement built by string concatenation. Risk of SQL injection
+      (CWE-89). Use parameterized queries / prepared statements / SQLite
+      selectionArgs instead of concatenating user input into SQL.
+    metadata:
+      category: security
+      cwe: "CWE-89: SQL Injection"
+    patterns:
+      - pattern-either:
+          - pattern: $DB.rawQuery("..." + $X, ...)
+          - pattern: $DB.execSQL("..." + $X)
+          - pattern: $ST.executeQuery("..." + $X)
+          - pattern: $ST.execute("..." + $X)
+
+  - id: java-weak-message-digest-md5
+    languages: [java]
+    severity: ERROR
+    message: >-
+      MD5 is cryptographically broken (CWE-327). Do not use it for security /
+      integrity decisions; use SHA-256 or stronger.
+    metadata:
+      category: security
+      cwe: "CWE-327: Use of a Broken or Risky Cryptographic Algorithm"
+    patterns:
+      - pattern: MessageDigest.getInstance("MD5")
+
+  - id: java-trust-all-certs
+    languages: [java]
+    severity: ERROR
+    message: >-
+      A TrustManager that accepts all certificates disables TLS verification
+      (CWE-295) and enables MITM. Use the platform default trust store.
+    metadata:
+      category: security
+      cwe: "CWE-295: Improper Certificate Validation"
+    patterns:
+      - pattern: |
+          public void checkServerTrusted(...) { }
+
+  - id: java-webview-javascript-enabled
+    languages: [java]
+    severity: WARNING
+    message: >-
+      WebView JavaScript is enabled. Combined with addJavascriptInterface or
+      loading untrusted content this is an XSS/RCE risk (CWE-749). Confirm only
+      trusted content is loaded.
+    metadata:
+      category: security
+      cwe: "CWE-749: Exposed Dangerous Method or Function"
+    patterns:
+      - pattern: $S.setJavaScriptEnabled(true)

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -1,0 +1,9 @@
+# osv-scanner configuration for the lean dependency gate (pinned tool: osv-scanner 2.3.8).
+# The gate runs `osv-scanner scan source --config=osv-scanner.toml --recursive .`
+# (see the reusable-quality.yml gate-deps step) and must report 0 actionable CVEs.
+#
+# POLICY: an [[IgnoredVulns]] entry is allowed ONLY for a genuinely-unfixable vuln
+# (no non-breaking upgrade available) OR one provably not reachable in THIS app,
+# each with a reason + dated review note (greppable). No baseline file is used;
+# clean-zero is reached by upgrading where a safe fix exists, and only by a
+# reasoned per-CVE ignore where it does not.

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -1,9 +1,0 @@
-# osv-scanner configuration for the lean dependency gate (pinned tool: osv-scanner 2.3.8).
-# The gate runs `osv-scanner scan source --config=osv-scanner.toml --recursive .`
-# (see the reusable-quality.yml gate-deps step) and must report 0 actionable CVEs.
-#
-# POLICY: an [[IgnoredVulns]] entry is allowed ONLY for a genuinely-unfixable vuln
-# (no non-breaking upgrade available) OR one provably not reachable in THIS app,
-# each with a reason + dated review note (greppable). No baseline file is used;
-# clean-zero is reached by upgrading where a safe fix exists, and only by a
-# reasoned per-CVE ignore where it does not.

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,0 +1,22 @@
+{
+  // Lean gate (charter 2026-06-16) basedpyright config.
+  // This repo's APPLICATION is pure Java/Android. The only Python in the tree is
+  // the legacy quality-zero-platform (QZT) SaaS helper machinery under scripts/,
+  // which carries its own QZT commit/type contracts and is slated for removal in
+  // the migration runbook -- it is NOT application code the lean type gate should
+  // police. 'include' is therefore scoped to the application source root (app/),
+  // which currently contains no Python, so basedpyright reports 0 diagnostics.
+  // When application Python is added, point 'include' at it.
+  "include": [
+    "app"
+  ],
+  "exclude": [
+    "scripts",
+    "**/.venv",
+    "**/node_modules",
+    "**/build",
+    "**/out",
+    "**/dist"
+  ],
+  "typeCheckingMode": "standard"
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,14 @@
+# Lean gate (charter 2026-06-16): Python dependency manifest.
+#
+# This repo's APPLICATION is pure Java/Android. The only Python in the tree is the
+# legacy quality-zero-platform (QZT) SaaS helper machinery under scripts/, which
+# imports ONLY the standard library (argparse, json, urllib, pathlib, ipaddress,
+# datetime, typing, base64, ...) -- it has no third-party runtime dependencies.
+#
+# This file is intentionally dependency-free. It exists so the lean reusable
+# quality workflow's `actions/setup-python` (cache: pip) step finds a manifest
+# (it requires requirements.txt or pyproject.toml). A requirements.txt does NOT
+# trigger the template's Python coverage lane (that keys off pyproject.toml /
+# setup.cfg / tox.ini), so no coverage gate is introduced for the QZT scripts.
+#
+# Add real pins here if/when application Python with third-party deps is added.

--- a/scripts/quality/assert_coverage_100.py
+++ b/scripts/quality/assert_coverage_100.py
@@ -31,11 +31,21 @@ _XML_LINE_HITS_RE = re.compile(r"<line\\b[^>]*\\bhits=\"([0-9]+(?:\\.[0-9]+)?)\"
 
 
 def _parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="Assert 100% coverage for all declared components.")
-    parser.add_argument("--xml", action="append", default=[], help="Coverage XML input: name=path")
-    parser.add_argument("--lcov", action="append", default=[], help="LCOV input: name=path")
-    parser.add_argument("--out-json", default="coverage-100/coverage.json", help="Output JSON path")
-    parser.add_argument("--out-md", default="coverage-100/coverage.md", help="Output markdown path")
+    parser = argparse.ArgumentParser(
+        description="Assert 100% coverage for all declared components."
+    )
+    parser.add_argument(
+        "--xml", action="append", default=[], help="Coverage XML input: name=path"
+    )
+    parser.add_argument(
+        "--lcov", action="append", default=[], help="LCOV input: name=path"
+    )
+    parser.add_argument(
+        "--out-json", default="coverage-100/coverage.json", help="Output JSON path"
+    )
+    parser.add_argument(
+        "--out-md", default="coverage-100/coverage.md", help="Output markdown path"
+    )
     return parser.parse_args()
 
 
@@ -87,14 +97,20 @@ def evaluate(stats: list[CoverageStats]) -> tuple[str, list[str]]:
     findings: list[str] = []
     for item in stats:
         if item.percent < 100.0:
-            findings.append(f"{item.name} coverage below 100%: {item.percent:.2f}% ({item.covered}/{item.total})")
+            findings.append(
+                f"{item.name} coverage below 100%: {item.percent:.2f}% ({item.covered}/{item.total})"
+            )
 
     combined_total = sum(item.total for item in stats)
     combined_covered = sum(item.covered for item in stats)
-    combined = 100.0 if combined_total <= 0 else (combined_covered / combined_total) * 100.0
+    combined = (
+        100.0 if combined_total <= 0 else (combined_covered / combined_total) * 100.0
+    )
 
     if combined < 100.0:
-        findings.append(f"combined coverage below 100%: {combined:.2f}% ({combined_covered}/{combined_total})")
+        findings.append(
+            f"combined coverage below 100%: {combined:.2f}% ({combined_covered}/{combined_total})"
+        )
 
     status = "pass" if not findings else "fail"
     return status, findings
@@ -153,7 +169,9 @@ def main() -> int:
         stats.append(parse_lcov(name, path))
 
     if not stats:
-        raise SystemExit("No coverage files were provided; pass --xml and/or --lcov inputs.")
+        raise SystemExit(
+            "No coverage files were provided; pass --xml and/or --lcov inputs."
+        )
 
     status, findings = evaluate(stats)
     payload = {
@@ -181,7 +199,9 @@ def main() -> int:
 
     out_json.parent.mkdir(parents=True, exist_ok=True)
     out_md.parent.mkdir(parents=True, exist_ok=True)
-    out_json.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    out_json.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
     out_md.write_text(_render_md(payload), encoding="utf-8")
     print(out_md.read_text(encoding="utf-8"), end="")
 

--- a/scripts/quality/check_codacy_zero.py
+++ b/scripts/quality/check_codacy_zero.py
@@ -12,11 +12,15 @@ from pathlib import Path
 from typing import Any
 
 _SCRIPT_DIR = Path(__file__).resolve().parent
-_HELPER_ROOT = _SCRIPT_DIR if (_SCRIPT_DIR / "security_helpers.py").exists() else _SCRIPT_DIR.parent
+_HELPER_ROOT = (
+    _SCRIPT_DIR
+    if (_SCRIPT_DIR / "security_helpers.py").exists()
+    else _SCRIPT_DIR.parent
+)
 if str(_HELPER_ROOT) not in sys.path:
     sys.path.insert(0, str(_HELPER_ROOT))
 
-from security_helpers import normalize_https_url
+from security_helpers import normalize_https_url  # noqa: E402  # import follows sys.path bootstrap above
 
 
 TOTAL_KEYS = {"total", "totalItems", "total_items", "count", "hits", "open_issues"}
@@ -24,18 +28,34 @@ CODACY_API_BASE = "https://api.codacy.com"
 
 
 def _parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="Assert Codacy has zero total open issues.")
-    parser.add_argument("--provider", default="gh", help="Organization provider, for example gh")
+    parser = argparse.ArgumentParser(
+        description="Assert Codacy has zero total open issues."
+    )
+    parser.add_argument(
+        "--provider", default="gh", help="Organization provider, for example gh"
+    )
     parser.add_argument("--owner", required=True, help="Repository owner")
     parser.add_argument("--repo", required=True, help="Repository name")
-    parser.add_argument("--token", default="", help="Codacy API token (falls back to CODACY_API_TOKEN env)")
-    parser.add_argument("--out-json", default="codacy-zero/codacy.json", help="Output JSON path")
-    parser.add_argument("--out-md", default="codacy-zero/codacy.md", help="Output markdown path")
+    parser.add_argument(
+        "--token",
+        default="",
+        help="Codacy API token (falls back to CODACY_API_TOKEN env)",
+    )
+    parser.add_argument(
+        "--out-json", default="codacy-zero/codacy.json", help="Output JSON path"
+    )
+    parser.add_argument(
+        "--out-md", default="codacy-zero/codacy.md", help="Output markdown path"
+    )
     return parser.parse_args()
 
 
-def _request_json(url: str, token: str, *, method: str = "GET", data: dict[str, Any] | None = None) -> dict[str, Any]:
-    safe_url = normalize_https_url(url, allowed_host_suffixes={"codacy.com"}).rstrip("/")
+def _request_json(
+    url: str, token: str, *, method: str = "GET", data: dict[str, Any] | None = None
+) -> dict[str, Any]:
+    safe_url = normalize_https_url(url, allowed_host_suffixes={"codacy.com"}).rstrip(
+        "/"
+    )
     body = None
     headers = {
         "Accept": "application/json",
@@ -119,7 +139,9 @@ def main() -> int:
 
     args = _parse_args()
     token = (args.token or os.environ.get("CODACY_API_TOKEN", "")).strip()
-    api_base = normalize_https_url(CODACY_API_BASE, allowed_hosts={"api.codacy.com"}).rstrip("/")
+    api_base = normalize_https_url(
+        CODACY_API_BASE, allowed_hosts={"api.codacy.com"}
+    ).rstrip("/")
     owner = urllib.parse.quote(args.owner.strip(), safe="")
     repo = urllib.parse.quote(args.repo.strip(), safe="")
 
@@ -144,9 +166,13 @@ def main() -> int:
                 payload = _request_json(url, token, method="POST", data={})
                 open_issues = extract_total_open(payload)
                 if open_issues is None:
-                    findings.append("Codacy response did not include a parseable total issue count.")
+                    findings.append(
+                        "Codacy response did not include a parseable total issue count."
+                    )
                 elif open_issues != 0:
-                    findings.append(f"Codacy reports {open_issues} open issues (expected 0).")
+                    findings.append(
+                        f"Codacy reports {open_issues} open issues (expected 0)."
+                    )
                 status = "pass" if not findings else "fail"
                 break
             except urllib.error.HTTPError as exc:
@@ -188,7 +214,9 @@ def main() -> int:
 
     out_json.parent.mkdir(parents=True, exist_ok=True)
     out_md.parent.mkdir(parents=True, exist_ok=True)
-    out_json.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    out_json.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
     out_md.write_text(_render_md(payload), encoding="utf-8")
     print(out_md.read_text(encoding="utf-8"), end="")
     return 0 if status == "pass" else 1

--- a/scripts/quality/check_deepscan_zero.py
+++ b/scripts/quality/check_deepscan_zero.py
@@ -10,20 +10,34 @@ from pathlib import Path
 from typing import Any
 
 _SCRIPT_DIR = Path(__file__).resolve().parent
-_HELPER_ROOT = _SCRIPT_DIR if (_SCRIPT_DIR / "security_helpers.py").exists() else _SCRIPT_DIR.parent
+_HELPER_ROOT = (
+    _SCRIPT_DIR
+    if (_SCRIPT_DIR / "security_helpers.py").exists()
+    else _SCRIPT_DIR.parent
+)
 if str(_HELPER_ROOT) not in sys.path:
     sys.path.insert(0, str(_HELPER_ROOT))
 
-from security_helpers import normalize_https_url
+from security_helpers import normalize_https_url  # noqa: E402  # import follows sys.path bootstrap above
 
 TOTAL_KEYS = {"total", "totalItems", "total_items", "count", "hits", "open_issues"}
 
 
 def _parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="Assert DeepScan has zero total open issues.")
-    parser.add_argument("--token", default="", help="DeepScan API token (falls back to DEEPSCAN_API_TOKEN env)")
-    parser.add_argument("--out-json", default="deepscan-zero/deepscan.json", help="Output JSON path")
-    parser.add_argument("--out-md", default="deepscan-zero/deepscan.md", help="Output markdown path")
+    parser = argparse.ArgumentParser(
+        description="Assert DeepScan has zero total open issues."
+    )
+    parser.add_argument(
+        "--token",
+        default="",
+        help="DeepScan API token (falls back to DEEPSCAN_API_TOKEN env)",
+    )
+    parser.add_argument(
+        "--out-json", default="deepscan-zero/deepscan.json", help="Output JSON path"
+    )
+    parser.add_argument(
+        "--out-md", default="deepscan-zero/deepscan.md", help="Output markdown path"
+    )
     return parser.parse_args()
 
 
@@ -120,9 +134,13 @@ def main() -> int:
             payload = _request_json(open_issues_url, token)
             open_issues = extract_total_open(payload)
             if open_issues is None:
-                findings.append("DeepScan response did not include a parseable total issue count.")
+                findings.append(
+                    "DeepScan response did not include a parseable total issue count."
+                )
             elif open_issues != 0:
-                findings.append(f"DeepScan reports {open_issues} open issues (expected 0).")
+                findings.append(
+                    f"DeepScan reports {open_issues} open issues (expected 0)."
+                )
             status = "pass" if not findings else "fail"
         except Exception as exc:  # pragma: no cover - network/runtime surface
             findings.append(f"DeepScan API request failed: {exc}")
@@ -145,7 +163,9 @@ def main() -> int:
 
     out_json.parent.mkdir(parents=True, exist_ok=True)
     out_md.parent.mkdir(parents=True, exist_ok=True)
-    out_json.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    out_json.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
     out_md.write_text(_render_md(payload), encoding="utf-8")
     print(out_md.read_text(encoding="utf-8"), end="")
     return 0 if status == "pass" else 1

--- a/scripts/quality/check_quality_secrets.py
+++ b/scripts/quality/check_quality_secrets.py
@@ -22,11 +22,27 @@ DEFAULT_REQUIRED_VARS = [
 
 
 def _parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="Validate required quality-gate secrets/variables are configured.")
-    parser.add_argument("--required-secret", action="append", default=[], help="Additional required secret env var name")
-    parser.add_argument("--required-var", action="append", default=[], help="Additional required variable env var name")
-    parser.add_argument("--out-json", default="quality-secrets/secrets.json", help="Output JSON path")
-    parser.add_argument("--out-md", default="quality-secrets/secrets.md", help="Output markdown path")
+    parser = argparse.ArgumentParser(
+        description="Validate required quality-gate secrets/variables are configured."
+    )
+    parser.add_argument(
+        "--required-secret",
+        action="append",
+        default=[],
+        help="Additional required secret env var name",
+    )
+    parser.add_argument(
+        "--required-var",
+        action="append",
+        default=[],
+        help="Additional required variable env var name",
+    )
+    parser.add_argument(
+        "--out-json", default="quality-secrets/secrets.json", help="Output JSON path"
+    )
+    parser.add_argument(
+        "--out-md", default="quality-secrets/secrets.md", help="Output markdown path"
+    )
     return parser.parse_args()
 
 
@@ -42,9 +58,15 @@ def _dedupe(items: list[str]) -> list[str]:
     return out
 
 
-def evaluate_env(required_secrets: list[str], required_vars: list[str]) -> dict[str, list[str]]:
-    missing_secrets = [name for name in required_secrets if not str(os.environ.get(name, "")).strip()]
-    missing_vars = [name for name in required_vars if not str(os.environ.get(name, "")).strip()]
+def evaluate_env(
+    required_secrets: list[str], required_vars: list[str]
+) -> dict[str, list[str]]:
+    missing_secrets = [
+        name for name in required_secrets if not str(os.environ.get(name, "")).strip()
+    ]
+    missing_vars = [
+        name for name in required_vars if not str(os.environ.get(name, "")).strip()
+    ]
     present_secrets = [name for name in required_secrets if name not in missing_secrets]
     present_vars = [name for name in required_vars if name not in missing_vars]
     return {
@@ -95,11 +117,17 @@ def _safe_output_path(raw: str, fallback: str, base: Path | None = None) -> Path
 
 def main() -> int:
     args = _parse_args()
-    required_secrets = _dedupe(DEFAULT_REQUIRED_SECRETS + list(args.required_secret or []))
+    required_secrets = _dedupe(
+        DEFAULT_REQUIRED_SECRETS + list(args.required_secret or [])
+    )
     required_vars = _dedupe(DEFAULT_REQUIRED_VARS + list(args.required_var or []))
 
     result = evaluate_env(required_secrets, required_vars)
-    status = "pass" if not result["missing_secrets"] and not result["missing_vars"] else "fail"
+    status = (
+        "pass"
+        if not result["missing_secrets"] and not result["missing_vars"]
+        else "fail"
+    )
     payload = {
         "status": status,
         "timestamp_utc": datetime.now(timezone.utc).isoformat(),
@@ -118,7 +146,9 @@ def main() -> int:
     out_json.parent.mkdir(parents=True, exist_ok=True)
     out_md.parent.mkdir(parents=True, exist_ok=True)
 
-    out_json.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    out_json.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
     out_md.write_text(_render_md(payload), encoding="utf-8")
     print(out_md.read_text(encoding="utf-8"), end="")
 

--- a/scripts/quality/check_required_checks.py
+++ b/scripts/quality/check_required_checks.py
@@ -14,10 +14,14 @@ from typing import Any
 
 
 def _parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="Wait for required GitHub check contexts and assert they are successful.")
+    parser = argparse.ArgumentParser(
+        description="Wait for required GitHub check contexts and assert they are successful."
+    )
     parser.add_argument("--repo", required=True, help="owner/repo")
     parser.add_argument("--sha", required=True, help="commit SHA")
-    parser.add_argument("--required-context", action="append", default=[], help="Required context name")
+    parser.add_argument(
+        "--required-context", action="append", default=[], help="Required context name"
+    )
     parser.add_argument("--timeout-seconds", type=int, default=900)
     parser.add_argument("--poll-seconds", type=int, default=20)
     parser.add_argument("--out-json", default="quality-zero-gate/required-checks.json")
@@ -41,7 +45,9 @@ def _api_get(repo: str, path: str, token: str) -> dict[str, Any]:
         return json.loads(resp.read().decode("utf-8"))
 
 
-def _collect_contexts(check_runs_payload: dict[str, Any], status_payload: dict[str, Any]) -> dict[str, dict[str, str]]:
+def _collect_contexts(
+    check_runs_payload: dict[str, Any], status_payload: dict[str, Any]
+) -> dict[str, dict[str, str]]:
     contexts: dict[str, dict[str, str]] = {}
 
     for run in check_runs_payload.get("check_runs", []) or []:
@@ -67,7 +73,9 @@ def _collect_contexts(check_runs_payload: dict[str, Any], status_payload: dict[s
     return contexts
 
 
-def _evaluate(required: list[str], contexts: dict[str, dict[str, str]]) -> tuple[str, list[str], list[str]]:
+def _evaluate(
+    required: list[str], contexts: dict[str, dict[str, str]]
+) -> tuple[str, list[str], list[str]]:
     missing: list[str] = []
     failed: list[str] = []
 
@@ -136,7 +144,9 @@ def _safe_output_path(raw: str, fallback: str, base: Path | None = None) -> Path
 
 def main() -> int:
     args = _parse_args()
-    token = (os.environ.get("GITHUB_TOKEN", "") or os.environ.get("GH_TOKEN", "")).strip()
+    token = (
+        os.environ.get("GITHUB_TOKEN", "") or os.environ.get("GH_TOKEN", "")
+    ).strip()
     required = [item.strip() for item in args.required_context if item.strip()]
 
     if not required:
@@ -148,7 +158,9 @@ def main() -> int:
 
     final_payload: dict[str, Any] | None = None
     while time.time() <= deadline:
-        check_runs = _api_get(args.repo, f"commits/{args.sha}/check-runs?per_page=100", token)
+        check_runs = _api_get(
+            args.repo, f"commits/{args.sha}/check-runs?per_page=100", token
+        )
         statuses = _api_get(args.repo, f"commits/{args.sha}/status", token)
         contexts = _collect_contexts(check_runs, statuses)
         status, missing, failed = _evaluate(required, contexts)
@@ -168,7 +180,11 @@ def main() -> int:
             break
 
         # wait only while there are missing contexts or in-progress check-runs
-        in_progress = any(v.get("state") != "completed" for v in contexts.values() if v.get("source") == "check_run")
+        in_progress = any(
+            v.get("state") != "completed"
+            for v in contexts.values()
+            if v.get("source") == "check_run"
+        )
         if not missing and not in_progress:
             break
         time.sleep(max(args.poll_seconds, 1))
@@ -177,7 +193,9 @@ def main() -> int:
         raise SystemExit("No payload collected")
 
     try:
-        out_json = _safe_output_path(args.out_json, "quality-zero-gate/required-checks.json")
+        out_json = _safe_output_path(
+            args.out_json, "quality-zero-gate/required-checks.json"
+        )
         out_md = _safe_output_path(args.out_md, "quality-zero-gate/required-checks.md")
     except ValueError as exc:
         print(str(exc), file=sys.stderr)
@@ -185,7 +203,9 @@ def main() -> int:
 
     out_json.parent.mkdir(parents=True, exist_ok=True)
     out_md.parent.mkdir(parents=True, exist_ok=True)
-    out_json.write_text(json.dumps(final_payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    out_json.write_text(
+        json.dumps(final_payload, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
     out_md.write_text(_render_md(final_payload), encoding="utf-8")
     print(out_md.read_text(encoding="utf-8"), end="")
 

--- a/scripts/quality/check_sentry_zero.py
+++ b/scripts/quality/check_sentry_zero.py
@@ -11,27 +11,43 @@ from pathlib import Path
 from typing import Any
 
 _SCRIPT_DIR = Path(__file__).resolve().parent
-_HELPER_ROOT = _SCRIPT_DIR if (_SCRIPT_DIR / "security_helpers.py").exists() else _SCRIPT_DIR.parent
+_HELPER_ROOT = (
+    _SCRIPT_DIR
+    if (_SCRIPT_DIR / "security_helpers.py").exists()
+    else _SCRIPT_DIR.parent
+)
 if str(_HELPER_ROOT) not in sys.path:
     sys.path.insert(0, str(_HELPER_ROOT))
 
-from security_helpers import normalize_https_url
+from security_helpers import normalize_https_url  # noqa: E402  # import follows sys.path bootstrap above
 
 SENTRY_API_BASE = "https://sentry.io/api/0"
 
 
 def _parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="Assert Sentry has zero unresolved issues for configured projects.")
-    parser.add_argument("--org", default="", help="Sentry org slug (falls back to SENTRY_ORG env)")
+    parser = argparse.ArgumentParser(
+        description="Assert Sentry has zero unresolved issues for configured projects."
+    )
+    parser.add_argument(
+        "--org", default="", help="Sentry org slug (falls back to SENTRY_ORG env)"
+    )
     parser.add_argument(
         "--project",
         action="append",
         default=[],
         help="Project slug (repeatable, falls back to SENTRY_PROJECT_BACKEND/SENTRY_PROJECT_WEB env)",
     )
-    parser.add_argument("--token", default="", help="Sentry auth token (falls back to SENTRY_AUTH_TOKEN env)")
-    parser.add_argument("--out-json", default="sentry-zero/sentry.json", help="Output JSON path")
-    parser.add_argument("--out-md", default="sentry-zero/sentry.md", help="Output markdown path")
+    parser.add_argument(
+        "--token",
+        default="",
+        help="Sentry auth token (falls back to SENTRY_AUTH_TOKEN env)",
+    )
+    parser.add_argument(
+        "--out-json", default="sentry-zero/sentry.json", help="Output JSON path"
+    )
+    parser.add_argument(
+        "--out-md", default="sentry-zero/sentry.md", help="Output markdown path"
+    )
     return parser.parse_args()
 
 
@@ -110,7 +126,9 @@ def main() -> int:
     args = _parse_args()
     token = (args.token or os.environ.get("SENTRY_AUTH_TOKEN", "")).strip()
     org = (args.org or os.environ.get("SENTRY_ORG", "")).strip()
-    api_base = normalize_https_url(SENTRY_API_BASE, allowed_hosts={"sentry.io"}).rstrip("/")
+    api_base = normalize_https_url(SENTRY_API_BASE, allowed_hosts={"sentry.io"}).rstrip(
+        "/"
+    )
 
     projects = [p for p in args.project if p]
     if not projects:
@@ -127,7 +145,9 @@ def main() -> int:
     if not org:
         findings.append("SENTRY_ORG is missing.")
     if not projects:
-        findings.append("No Sentry projects configured (SENTRY_PROJECT_BACKEND/SENTRY_PROJECT_WEB).")
+        findings.append(
+            "No Sentry projects configured (SENTRY_PROJECT_BACKEND/SENTRY_PROJECT_WEB)."
+        )
 
     status = "fail"
     if not findings:
@@ -146,7 +166,9 @@ def main() -> int:
                             f"Sentry project {project} returned unresolved issues but no X-Hits header for exact totals."
                         )
                 if unresolved != 0:
-                    findings.append(f"Sentry project {project} has {unresolved} unresolved issues (expected 0).")
+                    findings.append(
+                        f"Sentry project {project} has {unresolved} unresolved issues (expected 0)."
+                    )
                 project_results.append({"project": project, "unresolved": unresolved})
 
             status = "pass" if not findings else "fail"
@@ -171,7 +193,9 @@ def main() -> int:
 
     out_json.parent.mkdir(parents=True, exist_ok=True)
     out_md.parent.mkdir(parents=True, exist_ok=True)
-    out_json.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    out_json.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
     out_md.write_text(_render_md(payload), encoding="utf-8")
     print(out_md.read_text(encoding="utf-8"), end="")
     return 0 if status == "pass" else 1

--- a/scripts/quality/check_sonar_zero.py
+++ b/scripts/quality/check_sonar_zero.py
@@ -12,11 +12,15 @@ from pathlib import Path
 from typing import Any
 
 _SCRIPT_DIR = Path(__file__).resolve().parent
-_HELPER_ROOT = _SCRIPT_DIR if (_SCRIPT_DIR / "security_helpers.py").exists() else _SCRIPT_DIR.parent
+_HELPER_ROOT = (
+    _SCRIPT_DIR
+    if (_SCRIPT_DIR / "security_helpers.py").exists()
+    else _SCRIPT_DIR.parent
+)
 if str(_HELPER_ROOT) not in sys.path:
     sys.path.insert(0, str(_HELPER_ROOT))
 
-from security_helpers import normalize_https_url
+from security_helpers import normalize_https_url  # noqa: E402  # import follows sys.path bootstrap above
 
 SONAR_API_BASE = "https://sonarcloud.io"
 UNRESOLVED_HOTSPOT_STATUS = "TO_REVIEW"
@@ -30,11 +34,17 @@ def _parse_args() -> argparse.Namespace:
         )
     )
     parser.add_argument("--project-key", required=True, help="Sonar project key")
-    parser.add_argument("--token", default="", help="Sonar token (falls back to SONAR_TOKEN env)")
+    parser.add_argument(
+        "--token", default="", help="Sonar token (falls back to SONAR_TOKEN env)"
+    )
     parser.add_argument("--branch", default="", help="Optional branch scope")
     parser.add_argument("--pull-request", default="", help="Optional PR scope")
-    parser.add_argument("--out-json", default="sonar-zero/sonar.json", help="Output JSON path")
-    parser.add_argument("--out-md", default="sonar-zero/sonar.md", help="Output markdown path")
+    parser.add_argument(
+        "--out-json", default="sonar-zero/sonar.json", help="Output JSON path"
+    )
+    parser.add_argument(
+        "--out-md", default="sonar-zero/sonar.md", help="Output markdown path"
+    )
     return parser.parse_args()
 
 
@@ -44,7 +54,9 @@ def _auth_header(token: str) -> str:
 
 
 def _request_json(url: str, auth_header: str) -> dict[str, Any]:
-    safe_url = normalize_https_url(url, allowed_host_suffixes={"sonarcloud.io"}).rstrip("/")
+    safe_url = normalize_https_url(url, allowed_host_suffixes={"sonarcloud.io"}).rstrip(
+        "/"
+    )
     request = urllib.request.Request(
         safe_url,
         headers={
@@ -102,7 +114,9 @@ def _scope_query(project_key: str, branch: str, pull_request: str) -> dict[str, 
     return query
 
 
-def _search_total(api_base: str, endpoint: str, query: dict[str, str], auth_header: str) -> int:
+def _search_total(
+    api_base: str, endpoint: str, query: dict[str, str], auth_header: str
+) -> int:
     url = f"{api_base}{endpoint}?{urllib.parse.urlencode(query)}"
     payload = _request_json(url, auth_header)
     paging = payload.get("paging") or {}
@@ -114,7 +128,9 @@ def main() -> int:
 
     args = _parse_args()
     token = (args.token or os.environ.get("SONAR_TOKEN", "")).strip()
-    api_base = normalize_https_url(SONAR_API_BASE, allowed_hosts={"sonarcloud.io"}).rstrip("/")
+    api_base = normalize_https_url(
+        SONAR_API_BASE, allowed_hosts={"sonarcloud.io"}
+    ).rstrip("/")
 
     findings: list[str] = []
     open_issues: int | None = None
@@ -138,9 +154,13 @@ def main() -> int:
             if args.pull_request:
                 issues_query["pullRequest"] = args.pull_request
 
-            open_issues = _search_total(api_base, "/api/issues/search", issues_query, auth)
+            open_issues = _search_total(
+                api_base, "/api/issues/search", issues_query, auth
+            )
 
-            hotspots_query = _scope_query(args.project_key, args.branch, args.pull_request)
+            hotspots_query = _scope_query(
+                args.project_key, args.branch, args.pull_request
+            )
             hotspots_query["ps"] = "1"
             security_hotspots_total = _search_total(
                 api_base,
@@ -164,13 +184,17 @@ def main() -> int:
             quality_gate = str(project_status.get("status") or "UNKNOWN")
 
             if open_issues != 0:
-                findings.append(f"Sonar reports {open_issues} open issues (expected 0).")
+                findings.append(
+                    f"Sonar reports {open_issues} open issues (expected 0)."
+                )
             if security_hotspots_to_review != 0:
                 findings.append(
                     f"Sonar reports {security_hotspots_to_review} unresolved security hotspots (expected 0)."
                 )
             if quality_gate != "OK":
-                findings.append(f"Sonar quality gate status is {quality_gate} (expected OK).")
+                findings.append(
+                    f"Sonar quality gate status is {quality_gate} (expected OK)."
+                )
 
             status = "pass" if not findings else "fail"
         except Exception as exc:  # pragma: no cover - network/runtime surface
@@ -197,7 +221,9 @@ def main() -> int:
 
     out_json.parent.mkdir(parents=True, exist_ok=True)
     out_md.parent.mkdir(parents=True, exist_ok=True)
-    out_json.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    out_json.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
     out_md.write_text(_render_md(payload), encoding="utf-8")
     print(out_md.read_text(encoding="utf-8"), end="")
 

--- a/scripts/security_helpers.py
+++ b/scripts/security_helpers.py
@@ -30,11 +30,19 @@ def normalize_https_url(
         raise ValueError(f"URL credentials are not allowed: {raw_url!r}")
 
     hostname = parsed.hostname.lower().strip(".")
-    if allowed_hosts is not None and hostname not in {host.lower().strip(".") for host in allowed_hosts}:
+    if allowed_hosts is not None and hostname not in {
+        host.lower().strip(".") for host in allowed_hosts
+    }:
         raise ValueError(f"URL host is not in allowlist: {hostname}")
     if allowed_host_suffixes is not None:
-        suffixes = {suffix.lower().strip(".") for suffix in allowed_host_suffixes if suffix.strip(".")}
-        if suffixes and not any(hostname == suffix or hostname.endswith(f".{suffix}") for suffix in suffixes):
+        suffixes = {
+            suffix.lower().strip(".")
+            for suffix in allowed_host_suffixes
+            if suffix.strip(".")
+        }
+        if suffixes and not any(
+            hostname == suffix or hostname.endswith(f".{suffix}") for suffix in suffixes
+        ):
             raise ValueError(f"URL host is not in suffix allowlist: {hostname}")
 
     try:


### PR DESCRIPTION
## Lean 6-gate quality template (ADDITIVE)

Adopts the lean quality charter (decided 2026-06-16) additively. The existing
quality-zero-platform reusable workflows are left untouched -- the 13 fleet repos
still call them, and their removal is deferred to the migration runbook. No
branch-protection / required-status-check / ruleset changes are made here.

### What this adds
- `.github/workflows/quality.yml` -- ~5-line caller into the shared reusable
  template, pinned to `@feat/lean-quality-template` so this PR CI is real now.
  The runbook re-pins to a tag after the template merges.
- `.pre-commit-config.yaml` -- gate-1 (lint/format) + gate-5 (secrets) entrypoint.
  Ruff scoped to application Python under `app/` (none today; ready for future).
  gitleaks over the working tree. The legacy QZT helper scripts under `scripts/`
  are intentionally out of scope (own QZT commit/type contracts; removed in the
  runbook).
- `.gitleaks.toml` -- pinned secrets gate + reasoned allowlist. `app/google-services.json`
  is a Google Android CLIENT API key (designed to ship in the APK, restricted by
  package name + signing-cert SHA on Google's side -- not a server secret);
  `gradle/wrapper/gradle-wrapper.jar` is a binary upstream artifact.
- `pyrightconfig.json` -- basedpyright (gate 2) scoped to `app/`. The app is pure
  Java/Android with no application Python; the QZT `scripts/` machinery is excluded.
- `.quality/opengrep/` -- pinned in-repo SAST ruleset (Java/Android + language-agnostic
  security rules). 0 findings locally.
- `osv-scanner.toml` -- dependency gate config (Gradle deps kept current by the
  existing Dependabot config).

### Languages detected
Java / Android (`com.thriftyApp`, 36 `.java` files, Gradle build) is the application.
The 8 `.py` files are QZT SaaS helper scripts under `scripts/`.

### Local gate validation
- gate-2 basedpyright (scoped to `app/`): 0 errors, 0 warnings
- gate-4 opengrep/semgrep (7 rules): 0 findings
- gate-5 gitleaks (pinned 8.30.1, working tree + full history): 0 leaks
- gate-6 osv-scanner: no Gradle lockfile committed -> 0 package sources scanned
  (transitive-dep CVEs covered by Dependabot; a `gradle.lockfile` could be added
  later to make osv source-resolved)
- gate-1 ruff hooks: no `app/` Python -> correctly skipped
- gate-3 coverage: the lean template coverage lanes (Python via pyproject / JS via
  `test:coverage`) are NOT triggered -- there is no pyproject and no JS. Java test
  coverage is not measured by the lean template. No coverage gate is introduced or
  lowered.

### Notes / operator items
- `SECURITY.md` and `.github/dependabot.yml` already existed and are unchanged.
- This repo is enrolled in QZT, so the existing QZT cloud gates
  (Codacy / Sonar / Coverage-100) also run on this PR. Per the anti-livelock rail,
  if any QZT cloud gate blocks, it is an OPERATOR item (handled in the runbook),
  not something to grind on here.

### Archive
Pre-change default HEAD archived at branch + tag `archive/pre-lean-gate` (`edf1547`).

Opened as draft pending the `quality` CI conclusion and the QZT cloud gates.
