### PR TITLE
chore: remove DeepScan doc mention

### DIFF
--- a/docs/quality/QUALITY_GATES.md
+++ b/docs/quality/QUALITY_GATES.md
@@ -2,7 +2,7 @@
 
 This repository uses the **lean 6-gate** quality model (charter 2026-06-16). The previous
 "Quality Zero" / QZP machinery (mandatory zero-open findings on Sonar, Codacy, Semgrep,
-Sentry, DeepScan, gated behind required external tokens) has been **retired**; the lean
+Sentry, gated behind required external tokens) has been **retired**; the lean
 model is self-contained, requires no external SaaS tokens, and is the source of truth.
 
 ## CI checks


### PR DESCRIPTION
Removes the lingering DeepScan reference from docs/quality/QUALITY_GATES.md. DeepScan was part of the retired Quality Zero provider set; the lean 6-gate model no longer uses it, so the mention is dropped.