### PR TITLE
feat(quality): add curated .quality/opengrep ruleset (arms lean gate 4)

### DIFF
--- a/.quality/opengrep/README.md
+++ b/.quality/opengrep/README.md
@@ -1,0 +1,98 @@
+# Curated SAST ruleset (lean gate 4)
+
+Pinned tool: **opengrep 1.22.0** (CI, installed by
+`Prekzursil/quality-zero-platform/.github/workflows/reusable-quality.yml`) —
+locally interchangeable with **semgrep CE** (opengrep is a fork of semgrep and
+consumes the same rule syntax).
+
+## Why an in-repo ruleset instead of `--config auto`
+
+`--config auto` / `p/*` registry packs are fetched from the network at scan time
+and change underneath you: a repo that is green today goes red tomorrow with no
+change of yours. That externally-refreshing finding-set is exactly the treadmill
+the lean charter exists to escape. A fixed, reviewable ruleset committed to the
+repo makes the gate deterministic — same result every run, offline, no registry
+login — so **zero is both reachable and stable**.
+
+## Contents
+
+This repo is a single-module **Android application** written in Java
+(`gh api repos/Prekzursil/Personal-Finance-Management/languages` →
+`{"Java": 288337, "Shell": 903}`; 37 `.java` files under
+`app/src/main/java/com/thriftyApp/`, Gradle build, no Kotlin, no application
+Python — `requirements.txt` is deliberately empty scaffolding). The ruleset is
+scoped accordingly: SQLite, Google Sign-In / Drive backup, local credential
+hashing, WebView hardening.
+
+- `java-security.yaml` — 12 rules:
+  - **Injection** — SQL built by concatenation into `rawQuery`/`execSQL`/
+    `compileStatement`; `Runtime.exec`/`ProcessBuilder` with a non-literal command.
+  - **Crypto** — MD2/MD4/MD5/SHA-1 digests; DES/3DES/RC2/RC4/Blowfish or any
+    `/ECB/` cipher mode; `java.util.Random`/`Math.random()` for a
+    salt/token/key/nonce/IV.
+  - **TLS** — empty `checkServerTrusted`/`checkClientTrusted`;
+    `HostnameVerifier.verify` that unconditionally returns `true`; cleartext
+    `http://` URLs.
+  - **Android platform** — `setJavaScriptEnabled(true)`;
+    `setAllowUniversalAccessFromFileURLs` / `setAllowFileAccessFromFileURLs`;
+    `MODE_WORLD_READABLE`/`MODE_WORLD_WRITEABLE`; credential-shaped values
+    written to logcat.
+- `general-security.yaml` — 2 language-agnostic secret patterns (committed PEM
+  private key, AWS access key id). Defence-in-depth alongside gate 5 (gitleaks),
+  which uses a different engine.
+
+## Running the gate
+
+```bash
+# CI (opengrep, exactly as reusable-quality.yml gate 4 invokes it):
+opengrep scan --config .quality/opengrep --error \
+  --exclude .venv --exclude node_modules --exclude dist --exclude out --exclude build .
+
+# Local (semgrep CE, rule-compatible):
+semgrep scan --config .quality/opengrep --error --metrics off \
+  --exclude .venv --exclude node_modules --exclude dist --exclude out --exclude build .
+```
+
+Gate passes on **0 findings** (clean-zero lock; no baseline file).
+
+## Suppressions
+
+**None.** There are no `// nosemgrep` comments and no `paths: exclude` entries
+narrowing any rule to hide a hit — the application tree scans clean as written
+(parameterized `rawQuery` everywhere, PBKDF2 + `SecureRandom` in
+`PasswordHasher`, no WebView, no `Runtime.exec`, no cleartext endpoint).
+If a genuine false positive appears later, suppress it **inline** with a
+greppable `// nosemgrep: <rule-id> -- <reason>` on the line immediately above
+the finding (semgrep only honours the same line or the one directly above) and
+add a row here.
+
+## Refreshing against upstream
+
+Upstream registry rules (`p/java`, `p/r2c-security-audit`) are Apache-2.0 /
+LGPL-2.1; rule logic is reproduced / adapted here. To refresh, diff the registry
+packs and port new high-signal rules in one-in-one-out, re-running the control
+fixtures below.
+
+## Proving the ruleset can fire (do this on every change)
+
+A ruleset that has never gone red is indistinguishable from an empty file. Both
+states must be checked:
+
+```bash
+# KNOWN-BAD: must exit 1 and report every rule at least once
+opengrep scan --config .quality/opengrep --error /path/to/deliberately-vulnerable/
+# KNOWN-GOOD: must exit 0 with 0 findings AND print no "[ERROR] Rule parse error"
+opengrep scan --config .quality/opengrep --error /path/to/clean/
+```
+
+Check the known-good run's **exit code**, not just its finding count: opengrep
+exits **2** on a rule parse error while still printing `0 findings`, which would
+red the gate permanently. (That is a real trap — an early draft of
+`java-insecure-random-for-security` used the pattern `$T $V = new Random(...)`
+without the trailing `;`, which is not a parseable Java statement; it printed
+`0 findings` and exit 2.)
+
+Measured 2026-08-11 with opengrep 1.22.0: 14/14 rules fired on the known-bad
+fixture (exit 1, 26 findings); 0 findings and exit 0 on the known-good fixture;
+0 rule-parse errors in either run; `Ran 14 rules on 216 files: 0 findings`,
+exit 0, on this repo.

--- a/.quality/opengrep/general-security.yaml
+++ b/.quality/opengrep/general-security.yaml
@@ -1,0 +1,42 @@
+# Curated language-agnostic security rules (subset of p/r2c-security-audit).
+# opengrep/semgrep compatible. See README.md.
+rules:
+  - id: generic-private-key-committed
+    languages: [generic]
+    severity: ERROR
+    message: >-
+      A PEM private key block appears to be committed to source. Private keys
+      must never live in the repo; use a secret manager / env vars.
+    metadata:
+      category: security
+      cwe: "CWE-798: Use of Hard-coded Credentials"
+    paths:
+      exclude:
+        - "*.example"
+        - ".env.example"
+        - "**/tests/**"
+        - "**/fixtures/**"
+        - ".quality/opengrep/**"
+        - ".gitleaks.toml"
+    patterns:
+      - pattern-regex: "-----BEGIN (RSA |EC |OPENSSH |DSA |PGP )?PRIVATE KEY-----"
+
+  - id: generic-aws-access-key-id
+    languages: [generic]
+    severity: ERROR
+    message: >-
+      A string matching an AWS Access Key ID was found. Rotate it and move
+      credentials to a secret manager / environment variables.
+    metadata:
+      category: security
+      cwe: "CWE-798"
+    paths:
+      exclude:
+        - "*.example"
+        - ".env.example"
+        - "**/tests/**"
+        - "**/fixtures/**"
+        - ".quality/opengrep/**"
+        - ".gitleaks.toml"
+    patterns:
+      - pattern-regex: "\\b(AKIA|ASIA)[0-9A-Z]{16}\\b"

--- a/.quality/opengrep/java-security.yaml
+++ b/.quality/opengrep/java-security.yaml
@@ -1,0 +1,199 @@
+# Curated Java / Android security rules for the lean gate-4 (opengrep / Semgrep CE).
+# High-signal only, scoped to what this repo is: a single-module Android app
+# (SQLite via SQLiteOpenHelper, Google Sign-In + Drive backup, local PBKDF2
+# credential hashing). See README.md.
+rules:
+  - id: java-sql-string-concat
+    languages: [java]
+    severity: ERROR
+    message: >-
+      SQL built by string concatenation / String.format and handed to a SQLite
+      sink. Use a parameterized query (the selectionArgs / bindArgs overload).
+    metadata:
+      category: security
+      cwe: "CWE-89: SQL Injection"
+    patterns:
+      - pattern-either:
+          - pattern: $DB.rawQuery($Q, ...)
+          - pattern: $DB.execSQL($Q, ...)
+          - pattern: $DB.rawQueryWithFactory($F, $Q, ...)
+          - pattern: $DB.compileStatement($Q)
+      - metavariable-pattern:
+          metavariable: $Q
+          patterns:
+            - pattern-either:
+                - pattern: $A + $B
+                - pattern: String.format(...)
+                - pattern: $S.concat(...)
+
+  - id: java-runtime-exec-dynamic
+    languages: [java]
+    severity: ERROR
+    message: >-
+      Runtime.exec / ProcessBuilder invoked with a non-literal command. Validate
+      or allowlist the input, and prefer an explicit argument array.
+    metadata:
+      category: security
+      cwe: "CWE-78: OS Command Injection"
+    patterns:
+      - pattern-either:
+          - pattern: Runtime.getRuntime().exec($CMD, ...)
+          - pattern: new ProcessBuilder($CMD, ...)
+      - pattern-not: Runtime.getRuntime().exec("...", ...)
+      - pattern-not: new ProcessBuilder("...", ...)
+
+  - id: java-weak-hash-md5-sha1
+    languages: [java]
+    severity: ERROR
+    message: >-
+      Weak hash algorithm (MD2/MD5/SHA-1). For any security purpose use SHA-256+
+      or, for passwords, a KDF (PBKDF2 / scrypt / Argon2).
+    metadata:
+      category: security
+      cwe: "CWE-327: Use of a Broken or Risky Cryptographic Algorithm"
+    patterns:
+      - pattern: MessageDigest.getInstance($ALG, ...)
+      - metavariable-regex:
+          metavariable: $ALG
+          regex: "(?i)^\"(md2|md4|md5|sha-?1)\"$"
+
+  - id: java-weak-cipher-algorithm-or-mode
+    languages: [java]
+    severity: ERROR
+    message: >-
+      Broken cipher or ECB mode requested. Use AES/GCM/NoPadding (or
+      AES/CBC/PKCS5Padding with a random IV and a separate MAC).
+    metadata:
+      category: security
+      cwe: "CWE-327"
+    patterns:
+      - pattern: Cipher.getInstance($ALG, ...)
+      - metavariable-regex:
+          metavariable: $ALG
+          regex: "(?i)^\"(des|desede|tripledes|rc2|rc4|arcfour|blowfish)([/\"]|$)|^\"[^\"]*/ecb/"
+
+  - id: java-trustmanager-accepts-any-cert
+    languages: [java]
+    severity: ERROR
+    message: >-
+      X509TrustManager with an EMPTY checkServerTrusted/checkClientTrusted body
+      accepts every certificate, defeating TLS. Do not ship a permissive trust
+      manager; pin or use the platform trust store.
+    metadata:
+      category: security
+      cwe: "CWE-295: Improper Certificate Validation"
+    patterns:
+      - pattern-either:
+          - pattern: public void checkServerTrusted(...) {}
+          - pattern: public void checkClientTrusted(...) {}
+
+  - id: java-hostname-verifier-allows-any-host
+    languages: [java]
+    severity: ERROR
+    message: >-
+      HostnameVerifier.verify() unconditionally returns true, so any hostname is
+      accepted for any certificate (MITM). Use the default verifier.
+    metadata:
+      category: security
+      cwe: "CWE-297: Improper Validation of Certificate with Host Mismatch"
+    patterns:
+      - pattern: public boolean verify(...) { return true; }
+
+  - id: android-webview-javascript-enabled
+    languages: [java]
+    severity: ERROR
+    message: >-
+      JavaScript enabled in a WebView. If the WebView ever loads remote or
+      user-supplied content this is an XSS/RCE surface (especially with
+      addJavascriptInterface). Keep it off, or load only bundled assets.
+    metadata:
+      category: security
+      cwe: "CWE-79: Cross-site Scripting"
+    patterns:
+      - pattern: $S.setJavaScriptEnabled(true)
+
+  - id: android-webview-universal-file-access
+    languages: [java]
+    severity: ERROR
+    message: >-
+      WebView allowed to read file:// URLs from other origins. A single injected
+      script can then exfiltrate the app's private files.
+    metadata:
+      category: security
+      cwe: "CWE-200: Exposure of Sensitive Information"
+    patterns:
+      - pattern-either:
+          - pattern: $S.setAllowUniversalAccessFromFileURLs(true)
+          - pattern: $S.setAllowFileAccessFromFileURLs(true)
+
+  - id: android-world-accessible-file-mode
+    languages: [java]
+    severity: ERROR
+    message: >-
+      MODE_WORLD_READABLE / MODE_WORLD_WRITEABLE exposes app-private storage to
+      every other app on the device (and throws on API 24+). Use MODE_PRIVATE.
+    metadata:
+      category: security
+      cwe: "CWE-732: Incorrect Permission Assignment for Critical Resource"
+    patterns:
+      - pattern-either:
+          - pattern: MODE_WORLD_READABLE
+          - pattern: MODE_WORLD_WRITEABLE
+          - pattern: Context.MODE_WORLD_READABLE
+          - pattern: Context.MODE_WORLD_WRITEABLE
+
+  - id: java-insecure-random-for-security
+    languages: [java]
+    severity: ERROR
+    message: >-
+      java.util.Random / Math.random() is not cryptographically secure. Use
+      java.security.SecureRandom for salts, tokens, keys, IVs or nonces.
+    metadata:
+      category: security
+      cwe: "CWE-338: Use of Cryptographically Weak PRNG"
+    patterns:
+      - pattern-either:
+          - pattern: $T $V = new Random(...);
+          - pattern: $V = new Random(...);
+          - pattern: $T $V = Math.random();
+          - pattern: $V = Math.random();
+      - metavariable-regex:
+          metavariable: $V
+          regex: "(?i).*(token|secret|salt|nonce|key|password|passwd|otp|iv|session).*"
+
+  - id: java-cleartext-http-url
+    languages: [java]
+    severity: ERROR
+    message: >-
+      Cleartext http:// endpoint. Android blocks cleartext by default since API
+      28 for good reason - use https://.
+    metadata:
+      category: security
+      cwe: "CWE-319: Cleartext Transmission of Sensitive Information"
+    patterns:
+      - pattern-either:
+          - pattern: new URL($U)
+          - pattern: new java.net.URL($U)
+          - pattern: Uri.parse($U)
+          - pattern: android.net.Uri.parse($U)
+      - metavariable-regex:
+          metavariable: $U
+          regex: "^\"http://(?!localhost|127\\.0\\.0\\.1|10\\.0\\.2\\.2)"
+
+  - id: android-log-sensitive-value
+    languages: [java]
+    severity: ERROR
+    message: >-
+      A credential-shaped value is being written to logcat, which is readable by
+      the developer tooling and persisted in bug reports. Do not log secrets.
+    metadata:
+      category: security
+      cwe: "CWE-532: Insertion of Sensitive Information into Log File"
+    patterns:
+      - pattern-either:
+          - pattern: Log.$M($TAG, $MSG)
+          - pattern: Log.$M($TAG, $MSG, $E)
+          - pattern: android.util.Log.$M($TAG, $MSG)
+      - metavariable-regex:
+          metavariable: $MSG
+          regex: "(?i).*(password|passwd|secret|api_?key|access_?token|credential|private_?key).*"


### PR DESCRIPTION
feat(quality): add curated .quality/opengrep ruleset (arms lean gate 4)

This repo shipped no `.quality/opengrep`, so the lean gate's SAST lane (gate 4
of reusable-quality.yml) was skipped entirely and the `quality` job still
reported success -- a skip-and-pass. This adds the missing pinned, in-repo
ruleset so gate 4 actually runs.

## What lands

- `.quality/opengrep/java-security.yaml` -- 12 curated Java/Android rules:
  - **Injection** -- SQL built by concatenation / `String.format` into
    `rawQuery`/`execSQL`/`compileStatement`; `Runtime.exec`/`ProcessBuilder`
    with a non-literal command.
  - **Crypto** -- MD2/MD4/MD5/SHA-1 digests; DES/3DES/RC2/RC4/Blowfish or any
    `/ECB/` cipher mode; `java.util.Random` / `Math.random()` used for a
    salt/token/key/nonce/IV.
  - **TLS** -- empty `checkServerTrusted`/`checkClientTrusted`;
    `HostnameVerifier.verify` that unconditionally returns `true`; cleartext
    `http://` URLs.
  - **Android platform** -- `setJavaScriptEnabled(true)`;
    `setAllowUniversalAccessFromFileURLs`/`setAllowFileAccessFromFileURLs`;
    `MODE_WORLD_READABLE`/`MODE_WORLD_WRITEABLE`; credential-shaped values
    written to logcat.
- `.quality/opengrep/general-security.yaml` -- 2 language-agnostic secret
  patterns (committed PEM private key, AWS access key id).
- `.quality/opengrep/README.md` -- why an in-repo ruleset instead of
  `--config auto`, the exact CI/local invocations, the suppression policy, and
  the both-states proof procedure.

No application source is touched by this PR.

## Why curated + pinned, not `--config auto`

A registry-fetched ruleset changes underneath you: green today, red tomorrow
with no change of yours. That externally-refreshing finding set is the treadmill
the lean charter exists to escape. A fixed in-repo ruleset makes the gate
deterministic, so zero is both reachable and stable.

## Verification (measured 2026-08-11, opengrep 1.22.0 -- the CI pin)

Both states were checked; a ruleset that has never gone red is indistinguishable
from an empty file.

- KNOWN-BAD control (a deliberately vulnerable `Vuln.java` exercising all 12
  Java rules + a fake PEM/AKIA fixture, outside the repo): **14/14 rules fired,
  26 findings, exit 1**.
- KNOWN-GOOD control (safe equivalents -- parameterized queries, SHA-256,
  AES/GCM, a real trust check, `SecureRandom`, `MODE_PRIVATE`, https):
  **0 findings, exit 0, 0 rule-parse errors**.
- REAL repo, gate-4 invocation replayed verbatim
  (`opengrep scan --config .quality/opengrep --error --exclude .venv --exclude
  node_modules --exclude dist --exclude out --exclude build .`):
  **`Ran 14 rules on 216 files: 0 findings`, exit 0**.
- gitleaks 8.30.1 (gate 5) on the tree with the new files: exit 0, 568 KB
  scanned; detector validated -- it exits 1 on the known-bad fixture.

## Findings on the real repo: zero, and why that is credible rather than empty

The application tree scans clean **as written**, not because anything was
excluded: every `rawQuery` call already uses the `selectionArgs` overload,
`PasswordHasher` uses PBKDF2WithHmacSHA256 + `SecureRandom`, there is no
WebView, no `Runtime.exec`, no cleartext endpoint and no MD5/SHA-1. There are
**no `nosemgrep` suppressions and no `paths: exclude` entries** in this ruleset.

## Gate-authoring trap this PR documents (README)

opengrep exits **2** on a rule parse error while still printing `0 findings` --
so a broken rule reads as "clean" if you only look at the finding count, and
reds the gate permanently in CI. An early draft of
`java-insecure-random-for-security` hit exactly this (`$T $V = new Random(...)`
without the trailing `;` is not a parseable Java statement). The README tells
the next author to check the exit code, not the count.

## Out of scope, flagged for follow-up

This repo also ships **no `osv-scanner.toml`**, so lean gate 6 (dependencies)
never runs on it either -- the Gradle dependency tree is currently unscanned.
That is a separate change and is deliberately not bundled here.
